### PR TITLE
Add Hantascan visual analytics tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Related Awesome lists:
 ## Tools
 
 - [CadenceEVA](https://github.com/VACLab/CadenceEVA) - a visual analytics platform for event sequence analysis
+- [Hantascan](https://hantascan.com) - a live global hantavirus map showing reported cases, deaths, country totals, and outbreak locations.
 - [PyHealth](https://github.com/sunlabuiuc/PyHealth) - a Python Library for Healthcare Predictive Tasks
 - [SandDance](https://microsoft.github.io/SandDance/app/) - SandDance is a web-based application that enables you to more easily explore, identify, and communicate insights about tabular data.
 


### PR DESCRIPTION
## Summary
- Add Hantascan to Tools as a public visual analytics resource for hantavirus reports.
- The entry uses the list's existing one-line tool format.

## Test plan
- Documentation-only change; not run.


Made with [Cursor](https://cursor.com)